### PR TITLE
Improve hostname detection for HELO with Sys::Hostname::Long (RT 36112)

### DIFF
--- a/lib/Mail/Sendmail.pm
+++ b/lib/Mail/Sendmail.pm
@@ -53,6 +53,7 @@ our $auth_support;
 use Socket;
 use Time::Local; # for automatic time zone detection
 use Sys::Hostname; # for use of hostname in HELO
+use Sys::Hostname::Long; # for use of hostname in HELO
 
 #use Digest::HMAC_MD5 qw(hmac_md5 hmac_md5_hex);
 
@@ -339,7 +340,7 @@ sub sendmail {
     }
 
     # get local hostname for polite HELO
-    $localhost = hostname() || 'localhost';
+    $localhost = hostname_long() || hostname() || 'localhost';
 
     foreach $server ( @{$mailcfg{'smtp'}} ) {
         # open socket needs to be inside this foreach loop on Linux,


### PR DESCRIPTION
This PR simply applies the suggested patch in [RT 36112](https://rt.cpan.org/Ticket/Display.html?id=36112). I see no reason not to include this but if you decide against it, please update that ticket with the decision and rationale so it doesn't just stay unresolved.

