### PR TITLE
Fix typos in POD and comments

### DIFF
--- a/lib/Mail/Sendmail.pm
+++ b/lib/Mail/Sendmail.pm
@@ -545,7 +545,7 @@ sub sendmail {
             || return fail("send $header: error");
     };
 
-    #- test diconnecting from network here, to see what happens
+    #- test disconnecting from network here, to see what happens
     #- print STDERR "DISCONNECT NOW!\n";
     #- sleep 4;
     #- print STDERR "trying to continue, expecting an error... \n";
@@ -757,7 +757,7 @@ $mail{server}='my.smtp.server:2525' will try to connect to port 2525 on server m
 
 =item $mail{auth}
 
-This must be a reference to a hash containg all your authentication options:
+This must be a reference to a hash containing all your authentication options:
 
 $mail{auth} = \%options;
 or
@@ -967,7 +967,7 @@ from your scripts.
 
 
   $mail{Smtp} = 'special_server.for-this-message-only.domain.com';
-  $mail{'X-custom'} = 'My custom additionnal header';
+  $mail{'X-custom'} = 'My custom additional header';
   $mail{'mESSaGE : '} = "The message key looks terrible, but works.";
   # cheat on the date:
   $mail{Date} = Mail::Sendmail::time_to_date( time() - 86400 );
@@ -1018,7 +1018,7 @@ terrible things will happen to you if you use it badly, like for sending
 spam, or ...?)
 
 Thanks to the many users who sent me feedback, bug reports, suggestions, etc.
-And please excuse me if I forgot to answer your mail. I am not always reliabe
+And please excuse me if I forgot to answer your mail. I am not always reliable
 in answering mail. I intend to set up a mailing list soon.
 
 Last revision: 06.02.2003. Latest version should be available on


### PR DESCRIPTION
This fixes a few typos in the POD and 1 in a comment which includes the 2 remaining from [RT 88351](https://rt.cpan.org/Ticket/Display.html?id=88351)