### PR TITLE
Avoid splitting base64-encoded single fields (RT 123211)

### DIFF
--- a/lib/Mail/Sendmail.pm
+++ b/lib/Mail/Sendmail.pm
@@ -439,11 +439,11 @@ sub sendmail {
                     || return fail("send AUTH LOGIN failed (lost connection?)");
                 socket_read()
                     || return fail("AUTH LOGIN failed: $server_reply");
-                socket_write(encode_base64($auth->{user},$CRLF))
+                socket_write(encode_base64($auth->{user},'').$CRLF)
                     || return fail("send LOGIN username failed (lost connection?)");
                 socket_read()
                     || return fail("LOGIN username failed: $server_reply");
-                socket_write(encode_base64($auth->{password},$CRLF))
+                socket_write(encode_base64($auth->{password},'').$CRLF)
                     || return fail("send LOGIN password failed (lost connection?)");
                 socket_read()
                     || return fail("LOGIN password failed: $server_reply");
@@ -452,7 +452,7 @@ sub sendmail {
                 warn "Trying AUTH PLAIN\n" if ($mailcfg{debug} > 9);
                 socket_write(
                     "AUTH PLAIN "
-                    . encode_base64(join("\0", $auth->{user}, $auth->{user}, $auth->{password}), $CRLF)
+                    . encode_base64(join("\0", $auth->{user}, $auth->{user}, $auth->{password}), '') . $CRLF
                 ) || return fail("send AUTH PLAIN failed (lost connection?)");
                 socket_read()
                     || return fail("AUTH PLAIN failed: $server_reply");
@@ -466,7 +466,7 @@ sub sendmail {
                     || return fail("AUTH CRAM-MD5 failed: $server_reply");
                 $challenge =~ s/^\d+\s+//;
                 my $response = _hmac_md5($auth->{password}, decode_base64($challenge));
-                socket_write(encode_base64("$auth->{user} $response", $CRLF))
+                socket_write(encode_base64("$auth->{user} $response", '').$CRLF)
                     || return fail("AUTH CRAM-MD5 failed: $server_reply");
                 socket_read()
                     || return fail("AUTH CRAM-MD5 failed: $server_reply");


### PR DESCRIPTION
As suggested in [RT 123211](https://rt.cpan.org/Ticket/Display.html?id=123211) this PR uses the empty-string separator for those calls to encode_base64 where a single field is being supplied (typically username or password). We don't have a test for this but the logic seems sound.